### PR TITLE
Replace LWP::Protocol::https with IO::Socket::SSL and Net::SSLeay

### DIFF
--- a/lib/Task/CPAN/Reporter.pm
+++ b/lib/Task/CPAN/Reporter.pm
@@ -18,7 +18,9 @@ to help users install common dependencies together.
 
 =pkg Test::Reporter::Transport::Metabase 1.999008
 
-=pkg LWP::Protocol::https 6.02
+=pkg IO::Socket::SSL 1.42
+
+=pkg Net::SSLeay 1.49
 
 =head1 USAGE
 


### PR DESCRIPTION
If/when cpan-testers/Metabase-Client-Simple#8 is merged, then Task::CPAN::Reporter should also be updated to reflect the new prerequisites for SSL support.
